### PR TITLE
Erlang is changing its 0.0 comparison behavior in OTP 27

### DIFF
--- a/src/jam_iso8601.erl
+++ b/src/jam_iso8601.erl
@@ -385,7 +385,7 @@ decimal_mark(false) ->
 
 render_fraction(undefined, _Options) ->
     "";
-render_fraction(#fraction{value=0.0}, _Options) ->
+render_fraction(#fraction{value=+0.0}, _Options) ->
     "";
 render_fraction(#fraction{value=Fraction, precision=Precision}, Options) ->
     AsInt = drop_zeroes(round(Fraction * math:pow(10, Precision))),


### PR DESCRIPTION
Thus requiring a pattern match change in my code.

For more detail:

https://erlangforums.com/t/in-erlang-otp-27-0-0-will-no-longer-be-exactly-equal-to-0-0/2586

Error message when compiling:

```src/jam_iso8601.erl:388:33: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.```